### PR TITLE
Add ReportBean example for changing PDF settings and exporting to PDF

### DIFF
--- a/stand-alone/com/microstrategy/samples/beans/reportbean/ExportPDF.java
+++ b/stand-alone/com/microstrategy/samples/beans/reportbean/ExportPDF.java
@@ -1,0 +1,72 @@
+package com.microstrategy.samples.beans.reportbean;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import com.microstrategy.samples.sessions.SessionManager;
+import com.microstrategy.web.app.utils.OptionsHelper;
+import com.microstrategy.web.beans.BeanFactory;
+import com.microstrategy.web.beans.ReportBean;
+import com.microstrategy.web.beans.WebBeanException;
+import com.microstrategy.web.objects.EnumWebReportExecutionModes;
+import com.microstrategy.web.objects.WebIServerSession;
+import com.microstrategy.web.objects.WebObjectsException;
+import com.microstrategy.web.objects.rw.EnumRWExportOrientation;
+import com.microstrategy.webapi.EnumDSSXMLReportObjects;
+
+public class ExportPDF {
+
+  public static void main(String[] args) {
+    
+    WebIServerSession session = SessionManager.getSessionWithDetails("APS-TSIEBLER-VM", "MicroStrategy Tutorial", "Administrator", "");
+    
+    String reportID = "F76698D44CC957971487B5A2E82956DF";
+    try {
+      System.out.println("Starting export workflow");
+      // run the export workflow
+      byte[] exportResults = exportReportToPDF(reportID, session);
+      System.out.println("Saving export to file");
+
+      // save the results to file
+      FileOutputStream fos = new FileOutputStream("/Users/tsiebler/Documents/EclipseCodeSavedFiles/reportOrientationExport.pdf");
+      fos.write(exportResults);
+      fos.close();
+      
+      System.out.println("Export complete");
+      
+    } catch (IllegalArgumentException | WebObjectsException | WebBeanException | IOException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+  }
+  
+  
+  public static byte[] exportReportToPDF(String reportID, WebIServerSession serverSession) throws IllegalArgumentException, WebObjectsException, WebBeanException {
+    ReportBean rb = (ReportBean)BeanFactory.getInstance().newBean("ReportBean");
+    
+    // Id of the object we wish to execute
+    rb.setObjectID(reportID);
+    
+    // session used for execution
+    rb.setSessionInfo(serverSession);
+    
+    // type of execution
+    rb.setExecutionMode(EnumWebReportExecutionModes.REPORT_MODE_PDF);
+    
+    /*
+     * Set PDF orientation settings on the report instance, prior to the export itself
+     */
+    rb.getReportInstance().setProperty(EnumDSSXMLReportObjects.DssXmlReportObjectMainTemplate, OptionsHelper.PDFPropertySetName, OptionsHelper.Orientation, "" + EnumRWExportOrientation.RW_EXPORT_ORIENTATION_LANDSCAPE);
+    rb.getReportInstance().setProperty(EnumDSSXMLReportObjects.DssXmlReportObjectMainTemplate, OptionsHelper.PDFPropertySetName, OptionsHelper.ReportPDFSettingsPresent,"1");
+
+    /*
+     * These changes need to be applied, after being set on the report, else they won't be used in the execution
+     */
+    rb.setApplyChangesOnCollectData(true); // Indicate we have changes to apply
+    rb.collectData(); // Trigger report apply changes and then execution
+    
+    // return PDF export result as byte array
+    return rb.getReportInstance().getPDFData();
+  }
+
+}

--- a/stand-alone/com/microstrategy/samples/beans/reportbean/ExportPDF.java
+++ b/stand-alone/com/microstrategy/samples/beans/reportbean/ExportPDF.java
@@ -21,14 +21,17 @@ public class ExportPDF {
     WebIServerSession session = SessionManager.getSessionWithDetails("APS-TSIEBLER-VM", "MicroStrategy Tutorial", "Administrator", "");
     
     String reportID = "F76698D44CC957971487B5A2E82956DF";
+    String pathToSavePDF = "/Users/tsiebler/Documents/EclipseCodeSavedFiles/reportOrientationExport.pdf";
+    
     try {
       System.out.println("Starting export workflow");
       // run the export workflow
       byte[] exportResults = exportReportToPDF(reportID, session);
+      
       System.out.println("Saving export to file");
 
       // save the results to file
-      FileOutputStream fos = new FileOutputStream("/Users/tsiebler/Documents/EclipseCodeSavedFiles/reportOrientationExport.pdf");
+      FileOutputStream fos = new FileOutputStream(pathToSavePDF);
       fos.write(exportResults);
       fos.close();
       
@@ -54,13 +57,23 @@ public class ExportPDF {
     rb.setExecutionMode(EnumWebReportExecutionModes.REPORT_MODE_PDF);
     
     /*
-     * Set PDF orientation settings on the report instance, prior to the export itself
+     * A change in orientation requires a change in PDF paper height and width
+     */
+    rb.getReportInstance().setProperty(EnumDSSXMLReportObjects.DssXmlReportObjectMainTemplate, OptionsHelper.PDFPropertySetName, OptionsHelper.PaperHeight, "8");
+    rb.getReportInstance().setProperty(EnumDSSXMLReportObjects.DssXmlReportObjectMainTemplate, OptionsHelper.PDFPropertySetName, OptionsHelper.PaperWidth, "11.5");
+
+    /*
+     * Set PDF orientation settings on the report instance
      */
     rb.getReportInstance().setProperty(EnumDSSXMLReportObjects.DssXmlReportObjectMainTemplate, OptionsHelper.PDFPropertySetName, OptionsHelper.Orientation, "" + EnumRWExportOrientation.RW_EXPORT_ORIENTATION_LANDSCAPE);
+    
+    /*
+     * Specify that PDF settings are present in this workflow
+     */
     rb.getReportInstance().setProperty(EnumDSSXMLReportObjects.DssXmlReportObjectMainTemplate, OptionsHelper.PDFPropertySetName, OptionsHelper.ReportPDFSettingsPresent,"1");
 
     /*
-     * These changes need to be applied, after being set on the report, else they won't be used in the execution
+     * Lastly, these changes need to be applied, after being set on the report, else they won't be used in the execution
      */
     rb.setApplyChangesOnCollectData(true); // Indicate we have changes to apply
     rb.collectData(); // Trigger report apply changes and then execution

--- a/stand-alone/com/microstrategy/samples/beans/reportbean/ExportPDF.java
+++ b/stand-alone/com/microstrategy/samples/beans/reportbean/ExportPDF.java
@@ -1,9 +1,8 @@
 package com.microstrategy.samples.beans.reportbean;
 
-import java.io.FileOutputStream;
-import java.io.IOException;
-
 import com.microstrategy.samples.sessions.SessionManager;
+import com.microstrategy.samples.util.FileHelper;
+
 import com.microstrategy.web.app.utils.OptionsHelper;
 import com.microstrategy.web.beans.BeanFactory;
 import com.microstrategy.web.beans.ReportBean;
@@ -14,36 +13,44 @@ import com.microstrategy.web.objects.WebObjectsException;
 import com.microstrategy.web.objects.rw.EnumRWExportOrientation;
 import com.microstrategy.webapi.EnumDSSXMLReportObjects;
 
+
 public class ExportPDF {
 
   public static void main(String[] args) {
     
-    WebIServerSession session = SessionManager.getSessionWithDetails("APS-TSIEBLER-VM", "MicroStrategy Tutorial", "Administrator", "");
+    // Connectivity for the intelligence server
+    String intelligenceServerName = "APS-TSIEBLER-VM";
+    String projectName = "MicroStrategy Tutorial";
+    String microstrategyUsername = "Administrator";
+    String microstrategyPassword = "";
     
+    // The GUID of the report to use
     String reportID = "F76698D44CC957971487B5A2E82956DF";
+
+    // Where to save the PDF
     String pathToSavePDF = "/Users/tsiebler/Documents/EclipseCodeSavedFiles/reportOrientationExport.pdf";
     
+    // Create our I-Server Session
+    WebIServerSession session = SessionManager.getSessionWithDetails(intelligenceServerName, projectName, microstrategyUsername, microstrategyPassword);
+    
     try {
+      // Execute the report and generate the export
       System.out.println("Starting export workflow");
-      // run the export workflow
       byte[] exportResults = exportReportToPDF(reportID, session);
       
-      System.out.println("Saving export to file");
-
-      // save the results to file
-      FileOutputStream fos = new FileOutputStream(pathToSavePDF);
-      fos.write(exportResults);
-      fos.close();
+      // Save the export results to file
+      System.out.println("Saving export to file");     
+      FileHelper.saveByteArrayToFile(exportResults, pathToSavePDF);
       
       System.out.println("Export complete");
-      
-    } catch (IllegalArgumentException | WebObjectsException | WebBeanException | IOException e) {
-      // TODO Auto-generated catch block
+    } catch (IllegalArgumentException | WebObjectsException | WebBeanException e) {
       e.printStackTrace();
     }
   }
   
-  
+  /*
+   * This example defines a custom PDF orientation before exporting a report to PDF.
+   */
   public static byte[] exportReportToPDF(String reportID, WebIServerSession serverSession) throws IllegalArgumentException, WebObjectsException, WebBeanException {
     ReportBean rb = (ReportBean)BeanFactory.getInstance().newBean("ReportBean");
     
@@ -57,18 +64,18 @@ public class ExportPDF {
     rb.setExecutionMode(EnumWebReportExecutionModes.REPORT_MODE_PDF);
     
     /*
-     * A change in orientation requires a change in PDF paper height and width
+     * A change in orientation requires a change in PDF paper height and width. This is required.
      */
     rb.getReportInstance().setProperty(EnumDSSXMLReportObjects.DssXmlReportObjectMainTemplate, OptionsHelper.PDFPropertySetName, OptionsHelper.PaperHeight, "8");
     rb.getReportInstance().setProperty(EnumDSSXMLReportObjects.DssXmlReportObjectMainTemplate, OptionsHelper.PDFPropertySetName, OptionsHelper.PaperWidth, "11.5");
 
     /*
-     * Set PDF orientation settings on the report instance
+     * Set PDF orientation settings on the report instance.
      */
     rb.getReportInstance().setProperty(EnumDSSXMLReportObjects.DssXmlReportObjectMainTemplate, OptionsHelper.PDFPropertySetName, OptionsHelper.Orientation, "" + EnumRWExportOrientation.RW_EXPORT_ORIENTATION_LANDSCAPE);
     
     /*
-     * Specify that PDF settings are present in this workflow
+     * Specify that PDF settings are present in this workflow. This is required.
      */
     rb.getReportInstance().setProperty(EnumDSSXMLReportObjects.DssXmlReportObjectMainTemplate, OptionsHelper.PDFPropertySetName, OptionsHelper.ReportPDFSettingsPresent,"1");
 

--- a/stand-alone/com/microstrategy/samples/beans/reportbean/README.md
+++ b/stand-alone/com/microstrategy/samples/beans/reportbean/README.md
@@ -1,0 +1,7 @@
+# MicroStrategy ReportBean Workflows
+
+The ReportBean can be used to execute and render a report.
+
+## Further Reading
+- [Report Bean - Documentation & Examples](https://lw.microstrategy.com/msdz/MSDL/GARelease_Current/docs/projects/WebSDK/Content/topics/objbeans/Report_Bean.htm)
+- [Report Bean API Reference](https://lw.microstrategy.com/msdz/MSDL/GARelease_Current/docs/ReferenceFiles/reference/com/microstrategy/web/beans/ReportBean.html) - API documentation for ReportBean.

--- a/stand-alone/com/microstrategy/samples/objectmanager/PackageCreation.java
+++ b/stand-alone/com/microstrategy/samples/objectmanager/PackageCreation.java
@@ -1,11 +1,10 @@
 package com.microstrategy.samples.objectmanager;
 
-import java.io.*;
-
 import com.microstrategy.web.objects.*;
 import com.microstrategy.webapi.*;
 
 import com.microstrategy.samples.sessions.SessionManager;
+import com.microstrategy.samples.util.FileHelper;
 
 public class PackageCreation {
 
@@ -79,7 +78,7 @@ public class PackageCreation {
     String fileName = "reportPackage";
     String pathToFile = localFolderPath + fileName + ".mmp";
 
-    saveByteArrayToFile(objectPackage, pathToFile);
+    FileHelper.saveByteArrayToFile(objectPackage, pathToFile);
 
     System.out.println("Saved package to: " + pathToFile);
     return objectPackage;
@@ -138,7 +137,7 @@ public class PackageCreation {
     String fileName = "multiObjectPackage";
     String pathToFile = localFolderPath + fileName + ".mmp";
     
-    saveByteArrayToFile(objectPackage, pathToFile);
+    FileHelper.saveByteArrayToFile(objectPackage, pathToFile);
 
     System.out.println("Saved package to: " + pathToFile);
   }
@@ -191,7 +190,7 @@ public class PackageCreation {
     // Save the package to a file
     String fileName = "multiObjectPackage";
     String pathToFile = localFolderPath + fileName + ".mmp";
-    saveByteArrayToFile(objectPackage, pathToFile);
+    FileHelper.saveByteArrayToFile(objectPackage, pathToFile);
 
     System.out.println("Saved package to: " + pathToFile);
   }
@@ -258,30 +257,6 @@ public class PackageCreation {
       conflictObjectParts,
       objectConflictResolutionRule
     );
-  }
-  
-  /*
-   * Helper function to save an in-memory object to file
-   */
-  public static void saveByteArrayToFile(byte[] byteArray, String targetFilePath) {
-    BufferedOutputStream bos = null;
-    FileOutputStream fos = null;
-    try {
-      fos = new FileOutputStream(new File(targetFilePath));
-      bos = new BufferedOutputStream(fos);
-      bos.write(byteArray);
-    } catch (IOException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-
-    } finally {
-      try {
-        bos.close();
-      } catch (IOException e) {
-        // TODO Auto-generated catch block
-        e.printStackTrace();
-      }
-    }
   }
 
 }

--- a/stand-alone/com/microstrategy/samples/objectmanager/UndoPackage.java
+++ b/stand-alone/com/microstrategy/samples/objectmanager/UndoPackage.java
@@ -4,11 +4,11 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 import com.microstrategy.samples.sessions.SessionManager;
+import com.microstrategy.samples.util.FileHelper;
 import com.microstrategy.web.objects.WebIServerSession;
 import com.microstrategy.web.objects.WebObjectsException;
 import com.microstrategy.web.objects.WebSourceManipulator;
 import com.microstrategy.webapi.EnumDSSXMLConflictResolution;
-
 
 public class UndoPackage {
   private static String localFolderPath = "/Users/tsiebler/Documents/EclipseCodeSavedFiles/";
@@ -52,9 +52,8 @@ public class UndoPackage {
     
     // save the undo package to file
     String pathToFile = localFolderPath + fileName + ".mmp";
-    PackageCreation.saveByteArrayToFile(undoPackage, pathToFile);
-
     System.out.println("Saved undo package to: " + pathToFile);
+    FileHelper.saveByteArrayToFile(undoPackage, pathToFile);
   }
   
 

--- a/stand-alone/com/microstrategy/samples/util/FileHelper.java
+++ b/stand-alone/com/microstrategy/samples/util/FileHelper.java
@@ -1,0 +1,30 @@
+package com.microstrategy.samples.util;
+
+import java.io.*;
+
+public class FileHelper {
+  /*
+   * Helper function to save an in-memory object to file
+   */
+  public static void saveByteArrayToFile(byte[] byteArray, String targetFilePath) {
+    BufferedOutputStream bos = null;
+    FileOutputStream fos = null;
+    
+    try {
+      fos = new FileOutputStream(targetFilePath);
+      bos = new BufferedOutputStream(fos);
+      bos.write(byteArray);
+      
+    } catch (IOException e) {
+      e.printStackTrace();
+
+    } finally {
+      try {
+        bos.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
- Moved generic saveByteArrayToFile() to dedicated class, less repeat code.
- Add reportBean export example that:
  - sets PDF orientation
  - applies changes and executes datasets
  - generates PDF result
  - saves it to file