### PR TITLE
Document selections sample - pollStatusOnly instead of pollStatus().

### DIFF
--- a/stand-alone/com/microstrategy/samples/beans/rwbean/DocumentSelectors.java
+++ b/stand-alone/com/microstrategy/samples/beans/rwbean/DocumentSelectors.java
@@ -121,8 +121,9 @@ public class DocumentSelectors {
     
     System.out.println("-> finished applying selector changes, executing dataset");
 
-    // request execution of the dataset again, since we've made dataset changes (via element selectors)
+    // Request messageId and execution status
     rwInstance.pollStatusOnly();
+    
     System.out.println("-> returning PDF export");
     
     // return the PDF export of the result

--- a/stand-alone/com/microstrategy/samples/beans/rwbean/DocumentSelectors.java
+++ b/stand-alone/com/microstrategy/samples/beans/rwbean/DocumentSelectors.java
@@ -122,7 +122,7 @@ public class DocumentSelectors {
     System.out.println("-> finished applying selector changes, executing dataset");
 
     // request execution of the dataset again, since we've made dataset changes (via element selectors)
-    rwInstance.pollStatus();
+    rwInstance.pollStatusOnly();
     System.out.println("-> returning PDF export");
     
     // return the PDF export of the result


### PR DESCRIPTION
Looks like pollStatusOnly is enough to return only messageId & status, no additional data is needed. Export still shows selection changes.